### PR TITLE
use fs.statSync to get file size instead of ws utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules/
 lib/
 coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.idea
 .nvmrc
 .gitignore
 .eslintrc.js

--- a/src/webpack-bundle-size-limit-plugin.ts
+++ b/src/webpack-bundle-size-limit-plugin.ts
@@ -4,7 +4,7 @@ import { Bundle, WebpackBundleSizeLimitPluginOptions } from './types';
 import { Compiler, compilation as compilationType } from 'webpack';
 import { processOptions } from './process-options';
 import { processAssetConfig } from './process-asset-config';
-import { execSync } from 'child_process';
+import { statSync } from 'fs';
 import { error } from './error';
 import { parseMaxSize } from './parse-max-size';
 
@@ -40,13 +40,8 @@ export class WebpackBundleSizeLimitPlugin {
   }
 
   private getSizeInBytes(asset: string, { outputPath }: Compiler): number {
-    return parseFloat(
-      execSync(
-        `wc -c ${outputPath}/${asset} | awk '{$1=$1};1' | cut -d$' ' -f1`
-      )
-        .toString()
-        .trim()
-    );
+    const stats = statSync(`${outputPath}/${asset}`);
+    return stats.size;
   }
 
   apply(compiler: Compiler): void {


### PR DESCRIPTION
The plugin doesn't work on windows because the ws utility is missing